### PR TITLE
revert changes in dynamic class import

### DIFF
--- a/django_wfe/__init__.py
+++ b/django_wfe/__init__.py
@@ -3,7 +3,7 @@ A Django app providing multi-step workflow execution tools.
 """
 
 from django.apps import AppConfig
-from .app_utils import execute_workflow, provide_input
+from .app_utils import execute_workflow, execute_workflow_sync, provide_input
 
 
 VERSION = (0, 1, 0)

--- a/django_wfe/models.py
+++ b/django_wfe/models.py
@@ -118,11 +118,18 @@ class Job(models.Model):
         :param path: python path (dot notation) to the class
         :return: class object under located under the provided path
         """
-        module_path, class_ = path.rsplit(".", 1)
-        module = importlib.import_module(module_path)
-        importlib.reload(module)
+        # TODO:
+        #  with the current Workflow definition implementation there is not possibility to
+        #  reload the module here looking for the newest changes -> it causes a new ID assignment
+        #  to already imported classes, which causes a mismatch, when parsing the workflow's DIGRAPH
+        #  when looking for the next step to execute.
+        #  Possibly, a simultaneous reload should be done here and in the Workflow definition files
+        #  Note: for import with reload please check removal of the deleted Workflows in wfe_watchdog
 
-        return getattr(module, class_)
+        module, class_ = path.rsplit(".", 1)
+        Class = getattr(importlib.import_module(module), class_)
+
+        return Class
 
     def execute(self):
         """

--- a/django_wfe/urls.py
+++ b/django_wfe/urls.py
@@ -2,7 +2,7 @@ from django.urls import path, include
 from rest_framework import routers
 from . import views
 
-app_name = "rest_framework"
+app_name = "django_wfe"
 
 router = routers.DefaultRouter()
 router.register(r"workflows", views.WorkflowViewSet)

--- a/django_wfe/utils.py
+++ b/django_wfe/utils.py
@@ -104,7 +104,12 @@ def update_wdk_models():
     # remove deleted workflows from the database
     for workflow in Workflow.objects.all():
         try:
-            Job.import_class(workflow.path)
+            # dynamic import of the Workflow class
+            module_path, class_ = workflow.path.rsplit(".", 1)
+            module = importlib.import_module(module_path)
+            importlib.reload(module)
+
+            WorkflowClass = getattr(module, class_)
         except Exception:
             workflow.deleted = True
             workflow.save()


### PR DESCRIPTION
with the current Workflow definition implementation there is not possibility to reload the module in the `Job._workflow_transition()` method, looking for the newest changes. It causes a new ID assignment to already imported classes, which causes a mismatch, when parsing the workflow's DIGRAPH when looking for the next step to execute.
Possibly, a simultaneous reload should be done here and in the Workflow definition files.
To be investigated in a scope of another task.